### PR TITLE
fix: unify content modal UI and harden LinkedIn extraction

### DIFF
--- a/src/content/contentScript.ts
+++ b/src/content/contentScript.ts
@@ -41,14 +41,14 @@ const showContentToast = (
       : '<path d="M12 8v5M12 16h.01" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" />';
 
   toast.innerHTML = `
-    <div class="toast-icon jobstride-toast-icon" aria-hidden="true">
+    <div class="jobstride-toast-icon" aria-hidden="true">
       <svg viewBox="0 0 24 24" fill="none">${icon}</svg>
     </div>
-    <div class="toast-content jobstride-toast-content">
-      <div class="toast-title jobstride-toast-title">${escapeContentHtml(title)}</div>
-      <div class="toast-message jobstride-toast-message">${escapeContentHtml(message)}</div>
+    <div class="jobstride-toast-content">
+      <div class="jobstride-toast-title">${escapeContentHtml(title)}</div>
+      <div class="jobstride-toast-message">${escapeContentHtml(message)}</div>
     </div>
-    <button class="toast-close jobstride-toast-close jobstride-icon-button" aria-label="Dismiss notification">
+    <button class="jobstride-toast-close jobstride-icon-button" aria-label="Dismiss notification">
       <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
         <path d="M18 6 6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
       </svg>
@@ -57,14 +57,14 @@ const showContentToast = (
 
   document.body.appendChild(toast);
 
-  const closeBtn = toast.querySelector('.toast-close');
+  const closeBtn = toast.querySelector('.jobstride-toast-close');
   closeBtn?.addEventListener('click', () => {
-    toast.classList.add('hiding');
+    toast.classList.add('jobstride-toast--hiding');
     setTimeout(() => toast.remove(), 300);
   });
   setTimeout(() => {
     if (toast.parentElement) {
-      toast.classList.add('hiding');
+      toast.classList.add('jobstride-toast--hiding');
       setTimeout(() => toast.remove(), 300);
     }
   }, 4000);
@@ -331,8 +331,21 @@ function createFloatingButton(jobSite: JobSite): void {
 
   const modal = window.createModalForm();
 
-  button.addEventListener('click', () => {
-    const jobDetails = jobSite.extractJobDetails();
+  button.addEventListener('click', async () => {
+    let jobDetails: JobDetails;
+
+    try {
+      jobDetails = await Promise.resolve(jobSite.extractJobDetails());
+    } catch {
+      jobDetails = {
+        company: '',
+        position: '',
+        location: '',
+        url: window.location.href,
+        jobDescription: '',
+        salaryRange: '',
+      };
+    }
 
     (modal.querySelector('#position') as HTMLInputElement).value =
       jobDetails.position || '';
@@ -350,7 +363,9 @@ function createFloatingButton(jobSite: JobSite): void {
     openJobTrackerModal(modal);
   });
 
-  const closeBtn = modal.querySelector('.close') as HTMLElement;
+  const closeBtn = modal.querySelector(
+    '.jobstride-dialog-close',
+  ) as HTMLElement;
   closeBtn.onclick = () => {
     closeJobTrackerModal(modal);
   };

--- a/src/content/sites/base.ts
+++ b/src/content/sites/base.ts
@@ -5,7 +5,7 @@ abstract class JobSite {
     return Promise.resolve(false);
   }
 
-  extractJobDetails(): JobDetails {
+  extractJobDetails(): JobDetails | Promise<JobDetails> {
     return {
       company: '',
       position: '',

--- a/src/content/sites/linkedin.ts
+++ b/src/content/sites/linkedin.ts
@@ -3,13 +3,19 @@ class LinkedIn extends JobSite {
     return {
       jobPage:
         '.job-view-layout, .jobs-search__job-details, .job-details-jobs-container',
-      company: '.job-details-jobs-unified-top-card__company-name a',
-      title: '.t-24.job-details-jobs-unified-top-card__job-title h1',
+      company:
+        '.job-details-jobs-unified-top-card__company-name a, .job-details-jobs-unified-top-card__company-name, .jobs-unified-top-card__company-name a, .jobs-unified-top-card__company-name',
+      title:
+        '.t-24.job-details-jobs-unified-top-card__job-title h1, .job-details-jobs-unified-top-card__job-title h1, .job-details-jobs-unified-top-card__job-title, .jobs-unified-top-card__job-title h1, .jobs-unified-top-card__job-title, .top-card-layout__title',
       location:
-        '.job-details-jobs-unified-top-card__primary-description-container .tvm__text:first-child',
+        '.job-details-jobs-unified-top-card__primary-description-container .tvm__text:first-child, .job-details-jobs-unified-top-card__primary-description-container .tvm__text, .jobs-unified-top-card__bullet, .jobs-unified-top-card__subtitle-primary-grouping .tvm__text:first-child, .topcard__flavor--bullet',
       description:
-        '.jobs-description__content .jobs-description-content__text--stretch',
+        '.jobs-description__content .jobs-description-content__text--stretch, .jobs-description-content__text, .jobs-description__content, #job-details, .description__text .show-more-less-html__markup, .show-more-less-html__markup',
     };
+  }
+
+  private cleanText(text: string): string {
+    return text.replace(/\s+/g, ' ').trim();
   }
 
   private isLinkedInJobUrl(): boolean {
@@ -28,6 +34,506 @@ class LinkedIn extends JobSite {
     }
   }
 
+  private getCurrentJobId(): string {
+    try {
+      const currentJobId = new URL(window.location.href).searchParams.get(
+        'currentJobId',
+      );
+
+      if (currentJobId) {
+        return currentJobId;
+      }
+    } catch {
+      const currentJobId = window.location.search.match(
+        /[?&]currentJobId=([^&]+)/,
+      )?.[1];
+
+      if (currentJobId) {
+        return decodeURIComponent(currentJobId);
+      }
+    }
+
+    return window.location.pathname.match(/\/jobs\/view\/(\d+)/)?.[1] || '';
+  }
+
+  private getJobDetailsRoot(root: ParentNode = document): ParentNode {
+    return (
+      root.querySelector(
+        '.jobs-search__job-details, .job-view-layout, .job-details-jobs-container, .jobs-details',
+      ) || root
+    );
+  }
+
+  private findText(root: ParentNode, selectors: string[]): string {
+    for (const selector of selectors) {
+      const text = root.querySelector(selector)?.textContent || '';
+      const cleanedText = this.cleanText(text);
+
+      if (cleanedText) {
+        return cleanedText;
+      }
+    }
+
+    return '';
+  }
+
+  private findHtmlText(root: ParentNode, selectors: string[]): string {
+    for (const selector of selectors) {
+      const html = root.querySelector(selector)?.innerHTML || '';
+
+      if (html) {
+        return window.convertHtmlToText(html);
+      }
+    }
+
+    return '';
+  }
+
+  private findMetaContent(root: ParentNode, selectors: string[]): string {
+    for (const selector of selectors) {
+      const element = root.querySelector(selector);
+      const content =
+        element?.getAttribute('content') || element?.textContent || '';
+      const cleanedContent = content ? this.cleanText(content) : '';
+
+      if (cleanedContent) {
+        return cleanedContent;
+      }
+    }
+
+    return '';
+  }
+
+  private parseTitleFromMetaTitle(title: string): Partial<JobDetails> {
+    const match = title.match(
+      /^(.*?)\s+hiring\s+(.*?)\s+in\s+(.*?)\s+\|\s+LinkedIn$/i,
+    );
+
+    if (!match) {
+      return {};
+    }
+
+    return {
+      company: this.cleanText(match[1] || ''),
+      position: this.cleanText(match[2] || ''),
+      location: this.cleanText(match[3] || ''),
+    };
+  }
+
+  private extractSalaryFromText(text: string): string {
+    const normalizedText = text.replace(/\s+/g, ' ');
+    const salaryPatterns = [
+      /\$\s?\d{1,3}(?:,\d{3})*(?:\.\d+)?\s?(?:-|–|—|to)\s?\$\s?\d{1,3}(?:,\d{3})*(?:\.\d+)?(?:\s?(?:USD|\/\s?(?:yr|year|hr|hour)))?/i,
+      /\$\s?\d{1,3}(?:,\d{3})*(?:\.\d+)?\s?(?:\/\s?(?:yr|year|hr|hour)|per\s+(?:year|hour))/i,
+      /\d{1,3}\s?[kK]\s?(?:-|–|—|to)\s?\d{1,3}\s?[kK](?:\s?(?:\/\s?(?:yr|year|hr|hour)|per\s+(?:year|hour)))?/i,
+    ];
+
+    for (const pattern of salaryPatterns) {
+      const salaryRange = normalizedText.match(pattern)?.[0];
+
+      if (salaryRange) {
+        return this.cleanText(salaryRange);
+      }
+    }
+
+    return '';
+  }
+
+  private extractVisibleJobDetails(root: ParentNode = document): JobDetails {
+    const selectors = this.getSelectors();
+    const detailsRoot = this.getJobDetailsRoot(root);
+    const titleSelectors = [
+      selectors.title,
+      '.jobs-search__job-details h1',
+      '.job-details-jobs-unified-top-card__container h1',
+      '.jobs-unified-top-card h1',
+      '.top-card-layout__title',
+      '.topcard__title',
+    ];
+    const companySelectors = [
+      selectors.company,
+      '.job-details-jobs-unified-top-card__primary-description-container a[href*="/company/"]',
+      '.jobs-unified-top-card__company-name a',
+      '.jobs-unified-top-card__company-name',
+      '.topcard__org-name-link',
+      '.topcard__flavor:first-child',
+      'a[href*="/company/"]',
+    ];
+    const locationSelectors = [
+      selectors.location,
+      '.job-details-jobs-unified-top-card__tertiary-description-container .tvm__text:first-child',
+      '.job-details-jobs-unified-top-card__primary-description-container span[dir="ltr"] + span + span',
+      '.jobs-unified-top-card__workplace-type',
+      '.topcard__flavor--bullet',
+    ];
+    const descriptionSelectors = [
+      selectors.description,
+      '.jobs-description-content__text--stretch',
+      '.jobs-description-content__text',
+      '.jobs-description__content',
+      '.description__text .show-more-less-html__markup',
+      '.show-more-less-html__markup',
+      '#job-details',
+    ];
+    const metaDetails = this.parseTitleFromMetaTitle(
+      this.findMetaContent(root, [
+        'meta[property="og:title"]',
+        'meta[name="twitter:title"]',
+        'title',
+      ]),
+    );
+    const jobDescription =
+      this.findHtmlText(detailsRoot, descriptionSelectors) ||
+      this.findMetaContent(root, [
+        'meta[property="og:description"]',
+        'meta[name="description"]',
+        'meta[name="twitter:description"]',
+      ]);
+
+    let salaryRange = '';
+    const jobDetailsButtons = root.querySelectorAll(
+      '.job-details-fit-level-preferences button strong',
+    );
+    for (const button of jobDetailsButtons) {
+      const text = button.textContent?.trim() || '';
+      if (text.includes('$') || text.match(/\d+[kK]\/yr/)) {
+        salaryRange = text;
+        break;
+      }
+    }
+
+    salaryRange =
+      salaryRange ||
+      this.findText(root, [
+        '.job-details-jobs-unified-top-card__job-insight-view-model-secondary',
+        '.jobs-unified-top-card__job-insight',
+        '.job-details-preferences-and-skills__pill',
+      ])
+        .split('\n')
+        .map((value) => this.extractSalaryFromText(value))
+        .find(Boolean) ||
+      this.extractSalaryFromText(jobDescription);
+
+    return {
+      company:
+        this.findText(detailsRoot, companySelectors) ||
+        metaDetails.company ||
+        '',
+      position:
+        this.findText(detailsRoot, titleSelectors) ||
+        metaDetails.position ||
+        '',
+      location:
+        this.findText(detailsRoot, locationSelectors) ||
+        metaDetails.location ||
+        '',
+      url: window.location.href,
+      jobDescription: jobDescription,
+      salaryRange: salaryRange,
+    };
+  }
+
+  private getString(value: unknown): string {
+    if (typeof value === 'string') {
+      return this.cleanText(value);
+    }
+
+    if (typeof value === 'number') {
+      return String(value);
+    }
+
+    if (value && typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      return (
+        this.getString(record.text) ||
+        this.getString(record.name) ||
+        this.getString(record.localizedName)
+      );
+    }
+
+    return '';
+  }
+
+  private getFirstString(
+    record: Record<string, unknown>,
+    keys: string[],
+  ): string {
+    for (const key of keys) {
+      const value = this.getString(record[key]);
+
+      if (value) {
+        return value;
+      }
+    }
+
+    return '';
+  }
+
+  private extractLocationFromValue(value: unknown): string {
+    if (!value) {
+      return '';
+    }
+
+    if (typeof value === 'string') {
+      return this.cleanText(value);
+    }
+
+    if (Array.isArray(value)) {
+      return this.extractLocationFromValue(value[0]);
+    }
+
+    if (typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      const address = record.address as Record<string, unknown> | undefined;
+      const addressParts = [
+        this.getString(address?.streetAddress),
+        this.getString(address?.addressLocality),
+        this.getString(address?.addressRegion),
+        this.getString(address?.postalCode),
+        this.getString(address?.addressCountry),
+      ].filter(Boolean);
+
+      return (
+        this.getFirstString(record, [
+          'formattedLocation',
+          'locationName',
+          'name',
+          'text',
+        ]) || addressParts.join(', ')
+      );
+    }
+
+    return '';
+  }
+
+  private extractSalaryFromValue(value: unknown): string {
+    if (!value) {
+      return '';
+    }
+
+    if (typeof value === 'string') {
+      return this.cleanText(value);
+    }
+
+    if (typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      const valueRecord = record.value as Record<string, unknown> | undefined;
+      const currency =
+        this.getString(record.currency) ||
+        this.getString(valueRecord?.currency);
+      const minValue =
+        this.getString(record.minValue) ||
+        this.getString(valueRecord?.minValue);
+      const maxValue =
+        this.getString(record.maxValue) ||
+        this.getString(valueRecord?.maxValue);
+
+      if (minValue && maxValue) {
+        return `${currency ? `${currency} ` : ''}${minValue} - ${maxValue}`;
+      }
+
+      return (
+        this.getFirstString(record, [
+          'text',
+          'formattedSalary',
+          'formattedBaseSalary',
+        ]) || this.extractSalaryFromValue(record.value)
+      );
+    }
+
+    return '';
+  }
+
+  private extractDetailsFromRecord(
+    record: Record<string, unknown>,
+  ): Partial<JobDetails> {
+    const hiringOrganization = record.hiringOrganization as
+      | Record<string, unknown>
+      | undefined;
+    const companyDetails = record.companyDetails as
+      | Record<string, unknown>
+      | undefined;
+    const company = companyDetails?.company as
+      | Record<string, unknown>
+      | undefined;
+    const rawDescription = this.getFirstString(record, [
+      'description',
+      'jobDescription',
+      'formattedDescription',
+    ]);
+
+    return {
+      company:
+        this.getFirstString(record, ['companyName', 'company']) ||
+        this.getString(company) ||
+        this.getString(hiringOrganization),
+      position: this.getFirstString(record, [
+        'title',
+        'jobTitle',
+        'jobPostingTitle',
+        'formattedTitle',
+      ]),
+      location:
+        this.getFirstString(record, ['formattedLocation', 'location']) ||
+        this.extractLocationFromValue(record.jobLocation),
+      jobDescription: rawDescription
+        ? window.convertHtmlToText(rawDescription)
+        : '',
+      salaryRange:
+        this.getFirstString(record, [
+          'salaryRange',
+          'formattedSalary',
+          'formattedBaseSalary',
+        ]) || this.extractSalaryFromValue(record.baseSalary),
+    };
+  }
+
+  private countDetails(details: Partial<JobDetails>): number {
+    return [
+      details.company,
+      details.position,
+      details.location,
+      details.jobDescription,
+      details.salaryRange,
+    ].filter((value) => value?.trim()).length;
+  }
+
+  private mergeDetails(
+    primary: JobDetails,
+    fallback: Partial<JobDetails>,
+  ): JobDetails {
+    return {
+      company: primary.company || fallback.company || '',
+      position: primary.position || fallback.position || '',
+      location: primary.location || fallback.location || '',
+      url: window.location.href,
+      jobDescription: primary.jobDescription || fallback.jobDescription || '',
+      salaryRange: primary.salaryRange || fallback.salaryRange || '',
+    };
+  }
+
+  private parseJsonCandidates(text: string): unknown[] {
+    const trimmedText = text
+      .trim()
+      .replace(/^<!--/, '')
+      .replace(/-->$/, '')
+      .trim();
+
+    if (!trimmedText.startsWith('{') && !trimmedText.startsWith('[')) {
+      return [];
+    }
+
+    try {
+      return [JSON.parse(trimmedText)];
+    } catch {
+      return [];
+    }
+  }
+
+  private extractStructuredJobDetails(root: ParentNode): Partial<JobDetails> {
+    const currentJobId = this.getCurrentJobId();
+    const candidates: Array<{
+      details: Partial<JobDetails>;
+      score: number;
+    }> = [];
+    const jsonElements = root.querySelectorAll(
+      'script[type="application/ld+json"], code',
+    );
+
+    const visit = (value: unknown, depth: number): void => {
+      if (!value || depth > 12) {
+        return;
+      }
+
+      if (Array.isArray(value)) {
+        value.forEach((item) => visit(item, depth + 1));
+        return;
+      }
+
+      if (typeof value !== 'object') {
+        return;
+      }
+
+      const record = value as Record<string, unknown>;
+      const details = this.extractDetailsFromRecord(record);
+      const detailCount = this.countDetails(details);
+
+      if (detailCount > 0) {
+        const mentionsCurrentJob =
+          currentJobId && JSON.stringify(record).includes(currentJobId);
+        const typeScore =
+          this.getString(record['@type']).toLowerCase() === 'jobposting'
+            ? 8
+            : 0;
+        candidates.push({
+          details,
+          score: detailCount + (mentionsCurrentJob ? 12 : 0) + typeScore,
+        });
+      }
+
+      Object.values(record).forEach((nestedValue) =>
+        visit(nestedValue, depth + 1),
+      );
+    };
+
+    for (const element of jsonElements) {
+      const text = element.textContent || element.innerHTML || '';
+      this.parseJsonCandidates(text).forEach((candidate) =>
+        visit(candidate, 0),
+      );
+    }
+
+    candidates.sort((a, b) => b.score - a.score);
+    return candidates[0]?.details || {};
+  }
+
+  private async fetchJobDetailsPage(url: string): Promise<Partial<JobDetails>> {
+    const response = await fetch(url, { credentials: 'include' });
+
+    if (!response.ok) {
+      return {};
+    }
+
+    const html = await response.text();
+    const documentFromResponse = new DOMParser().parseFromString(
+      html,
+      'text/html',
+    );
+    const visibleDetails = this.extractVisibleJobDetails(documentFromResponse);
+    const structuredDetails =
+      this.extractStructuredJobDetails(documentFromResponse);
+
+    return this.mergeDetails(visibleDetails, structuredDetails);
+  }
+
+  private async fetchCanonicalJobDetails(): Promise<Partial<JobDetails>> {
+    const currentJobId = this.getCurrentJobId();
+
+    if (!currentJobId) {
+      return {};
+    }
+
+    const urls = [
+      new URL(
+        `/jobs-guest/jobs/api/jobPosting/${currentJobId}`,
+        window.location.href,
+      ).href,
+      new URL(`/jobs/view/${currentJobId}/`, window.location.href).href,
+    ];
+
+    for (const url of urls) {
+      try {
+        const details = await this.fetchJobDetailsPage(url);
+
+        if (this.countDetails(details) > 0) {
+          return details;
+        }
+      } catch {}
+    }
+
+    return {};
+  }
+
   isJobPage(): Promise<boolean> {
     const selectors = this.getSelectors();
     return new Promise((resolve) => {
@@ -40,40 +546,19 @@ class LinkedIn extends JobSite {
     });
   }
 
-  extractJobDetails(): JobDetails {
-    const selectors = this.getSelectors();
-    const elements = {
-      company: document.querySelector(selectors.company),
-      title: document.querySelector(selectors.title),
-      location: document.querySelector(selectors.location),
-      description: document.querySelector(selectors.description),
-    };
+  async extractJobDetails(): Promise<JobDetails> {
+    const visibleDetails = this.extractVisibleJobDetails();
+    const structuredDetails = this.extractStructuredJobDetails(document);
+    let jobDetails = this.mergeDetails(visibleDetails, structuredDetails);
 
-    let description = '';
-    if (elements.description) {
-      description = window.convertHtmlToText(elements.description.innerHTML);
+    if (this.countDetails(jobDetails) < 3) {
+      jobDetails = this.mergeDetails(
+        jobDetails,
+        await this.fetchCanonicalJobDetails(),
+      );
     }
 
-    let salaryRange = '';
-    const jobDetailsButtons = document.querySelectorAll(
-      '.job-details-fit-level-preferences button strong',
-    );
-    for (const button of jobDetailsButtons) {
-      const text = button.textContent?.trim() || '';
-      if (text.includes('$') || text.match(/\d+[kK]\/yr/)) {
-        salaryRange = text;
-        break;
-      }
-    }
-
-    return {
-      company: elements.company?.textContent?.trim() || '',
-      position: elements.title?.textContent?.trim() || '',
-      location: elements.location?.textContent?.trim() || '',
-      url: window.location.href,
-      jobDescription: description,
-      salaryRange: salaryRange,
-    };
+    return jobDetails;
   }
 }
 

--- a/src/content/styles/contentStyle.css
+++ b/src/content/styles/contentStyle.css
@@ -109,22 +109,8 @@ body[data-site="rippling"] #job-tracker-btn {
   animation: jobstride-toast-in 180ms ease-out;
 }
 
-.job-tracker-toast.hiding {
+.job-tracker-toast.jobstride-toast--hiding {
   animation: jobstride-toast-out 180ms ease-in forwards;
-}
-
-.job-tracker-success {
-  position: fixed;
-  top: 24px;
-  right: 24px;
-  z-index: 2147483647;
-  padding: 12px 16px;
-  color: var(--jobstride-primary-foreground);
-  background: var(--jobstride-success);
-  border-radius: var(--jobstride-radius-md);
-  font: 650 14px / 1.3 var(--jobstride-font);
-  box-shadow: var(--jobstride-shadow-md);
-  animation: jobstride-fade-out 3s ease forwards;
 }
 
 @keyframes jobstride-float-in {
@@ -201,8 +187,7 @@ body[data-site="rippling"] #job-tracker-btn {
   #job-tracker-btn,
   #job-tracker-modal .jobstride-dialog-panel,
   .job-tracker-toast,
-  .job-tracker-toast.hiding,
-  .job-tracker-success {
+  .job-tracker-toast.jobstride-toast--hiding {
     animation-duration: 1ms;
   }
 }

--- a/src/content/utils/modal.ts
+++ b/src/content/utils/modal.ts
@@ -6,8 +6,8 @@ function createModalForm(): HTMLElement {
   modal.setAttribute('aria-modal', 'true');
   modal.setAttribute('aria-labelledby', 'job-tracker-modal-title');
   modal.innerHTML = `
-    <div class="modal-content jobstride-dialog-panel">
-      <div class="modal-header jobstride-dialog-header">
+    <div class="jobstride-dialog-panel">
+      <div class="jobstride-dialog-header">
         <div class="jobstride-brand">
           <span class="jobstride-brand-mark" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="none">
@@ -21,7 +21,7 @@ function createModalForm(): HTMLElement {
             <p class="jobstride-subtitle">Track this job</p>
           </div>
         </div>
-        <button class="close jobstride-icon-button" type="button" aria-label="Close">
+        <button class="jobstride-dialog-close jobstride-icon-button" type="button" aria-label="Close">
           <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
             <path d="M18 6 6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
           </svg>
@@ -30,41 +30,41 @@ function createModalForm(): HTMLElement {
       <form id="job-form-modal" class="jobstride-form">
         <div class="jobstride-dialog-body">
           <div class="jobstride-form-grid">
-            <div class="form-group jobstride-field">
+            <div class="jobstride-field">
               <label class="jobstride-label" for="dashboardName">Select Dashboard</label>
               <select id="dashboardName" class="jobstride-control jobstride-select" required>
                 <option value="" disabled selected>Choose a dashboard...</option>
               </select>
             </div>
-            <div class="form-group jobstride-field">
+            <div class="jobstride-field">
               <label class="jobstride-label" for="company">Company</label>
               <input type="text" id="company" class="jobstride-control" placeholder="e.g. Acme Inc." required />
             </div>
-            <div class="form-group jobstride-field">
+            <div class="jobstride-field">
               <label class="jobstride-label" for="position">Position</label>
               <input type="text" id="position" class="jobstride-control" placeholder="e.g. Senior Product Manager" required />
             </div>
-            <div class="form-group jobstride-field">
+            <div class="jobstride-field">
               <label class="jobstride-label" for="location">Location</label>
               <input type="text" id="location" class="jobstride-control" placeholder="e.g. Remote or New York, NY" required />
             </div>
-            <div class="form-group jobstride-field jobstride-field--full">
+            <div class="jobstride-field jobstride-field--full">
               <label class="jobstride-label" for="jobDescription">Job Description</label>
               <textarea id="jobDescription" class="jobstride-control jobstride-textarea" placeholder="Add notes about the role, requirements, etc."></textarea>
             </div>
-            <div class="form-group jobstride-field jobstride-field--full">
+            <div class="jobstride-field jobstride-field--full">
               <label class="jobstride-label" for="url">Job URL</label>
               <input type="url" id="url" class="jobstride-control" placeholder="https://jobboard.com/jobs/12345" />
             </div>
-            <div class="form-group jobstride-field jobstride-field--full">
+            <div class="jobstride-field jobstride-field--full">
               <label class="jobstride-label" for="salaryRange">Salary Range</label>
               <input type="text" id="salaryRange" class="jobstride-control" placeholder="e.g. $120,000 - $150,000" />
             </div>
           </div>
         </div>
-        <div class="form-actions jobstride-dialog-footer">
+        <div class="jobstride-dialog-footer">
           <button type="button" class="jobstride-dialog-cancel jobstride-button jobstride-button--secondary">Cancel</button>
-          <button type="submit" class="btn-primary jobstride-button jobstride-button--primary">
+          <button type="submit" class="jobstride-button jobstride-button--primary">
             <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
               <path d="M6 4.5h12v15l-6-3.5-6 3.5v-15Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
             </svg>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -72,7 +72,7 @@ interface RequestConfig {
 interface JobSiteHandler {
   getSelectors(): JobSelectors;
   isJobPage(): Promise<boolean>;
-  extractJobDetails(): JobDetails;
+  extractJobDetails(): JobDetails | Promise<JobDetails>;
 }
 
 interface SiteConfig {

--- a/src/shared/styles/jobstride-ui.css
+++ b/src/shared/styles/jobstride-ui.css
@@ -528,3 +528,27 @@
     animation-duration: 1.2s;
   }
 }
+
+#job-tracker-modal .jobstride-dialog-panel,
+#job-tracker-modal .jobstride-dialog-panel * {
+  box-sizing: border-box;
+  letter-spacing: 0;
+}
+
+#job-tracker-modal .jobstride-dialog-panel {
+  font-family: var(--jobstride-font);
+  color: var(--jobstride-foreground);
+  line-height: 1.5;
+}
+
+#job-tracker-modal .jobstride-field,
+#job-tracker-modal .jobstride-label {
+  margin: 0;
+  padding: 0;
+}
+
+#job-tracker-modal .jobstride-control,
+#job-tracker-modal .jobstride-button,
+#job-tracker-modal .jobstride-icon-button {
+  font-family: var(--jobstride-font);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,7 +72,7 @@ export interface RequestConfig {
 export interface JobSiteHandler {
   getSelectors(): JobSelectors;
   isJobPage(): Promise<boolean>;
-  extractJobDetails(): JobDetails;
+  extractJobDetails(): JobDetails | Promise<JobDetails>;
 }
 
 export interface SiteConfig {


### PR DESCRIPTION
Update supported job board content scripts to use the shared JobStride UI without legacy host-colliding classes, add UI contract tests, and make LinkedIn job detection/extraction resilient across search-results, jobs/view, structured data, and public job detail payloads.

<img width="759" height="740" alt="Screenshot 2026-05-27 at 6 26 02 PM" src="https://github.com/user-attachments/assets/a06e027d-0e25-4adc-867f-11cb7c20e88e" />
